### PR TITLE
GG-94 Asignar tráiler a contenidos

### DIFF
--- a/app.py
+++ b/app.py
@@ -420,5 +420,36 @@ def getSeriesParticipants():
     return SeriesCtrl.getSeriesParticipants(db['series'], db['participants'])
 
 
+# -------------------------------------------------------------------------------------------------------
+
+@app.route('/movies/<idMovie>/trailer', methods=['PUT'])
+def putTrailerIntoMovie(idMovie):
+    return MovieCtrl.putTrailerIntoMovie(db['movies'], db['trailers'], idMovie)
+
+
+@app.route('/series/<idSeries>/trailer', methods=['PUT'])
+def putTrailerIntoSeries(idSeries):
+    return SeriesCtrl.putTrailerIntoSeries(db['series'], db['trailers'], idSeries)
+
+
+@app.route('/seasons/<idSeason>/trailer', methods=['PUT'])
+def putTrailerIntoSeasons(idSeason):
+    return SeasonCtrl.putTrailerIntoSeason(db['seasons'], db['trailers'], idSeason)
+
+@app.route('/movies/<idMovie>/trailer', methods=['DELETE'])
+def deleteTrailerFromMovie(idMovie):
+    return MovieCtrl.deleteTrailerFromMovie(db['movies'], idMovie)
+
+
+@app.route('/series/<idSeries>/trailer', methods=['DELETE'])
+def deleteTrailerFromSeries(idSeries):
+    return SeriesCtrl.deleteTrailerFromSeries(db['series'], idSeries)
+
+
+@app.route('/seasons/<idSeason>/trailer', methods=['DELETE'])
+def deleteTrailerFromSeason(idSeason):
+    return SeasonCtrl.deleteTrailerFromSeason(db['seasons'], idSeason)
+
+
 if __name__ == '__main__':
     app.run(debug=True, port=8082)

--- a/controllers/movie_ctrl.py
+++ b/controllers/movie_ctrl.py
@@ -342,3 +342,38 @@ class MovieCtrl:
         return MovieCtrl.putMovie(db, idMovie)
 
 # --------------------------------
+
+    @staticmethod
+    def putTrailerIntoMovie(movies: Collection, trailers: Collection, idMovie: int):
+        idTrailer = request.args.get('idTrailer')
+        if idTrailer:
+            idTrailer = int(idTrailer)
+            if trailers.find({'idTrailer': idTrailer}):
+                filter = {'idMovie': int(idMovie)}
+                change = {'$set': {'trailer': idTrailer}}
+                result = movies.update_one(filter, change)
+                print(result)
+                if result.matched_count == 0:
+                    return jsonify({'error': 'Movie not found or not updated', 'status': '404 Not Found'}), 404
+                elif result.modified_count == 0:
+                    return jsonify({'message': 'New trailer matches with current trailer', 'status': '200 OK'}), 200
+                return redirect(url_for('movies'))
+            else:
+                return jsonify({'error': 'No trailer was found', 'status': '404 Not Found'}), 400
+        else:
+            return jsonify({'error': 'Missing data or incorrect method', 'status': '400 Bad Request'}), 400
+
+    @staticmethod
+    def deleteTrailerFromMovie(db: Collection, idMovie:int):
+        if idMovie:
+            filter = {'idMovie': int(idMovie)}
+            change = {'$set': {'trailer': None}}
+            result = db.update_one(filter, change)
+            print(result)
+            if result.matched_count == 0:
+                return jsonify({'error': 'Movie not found or not updated', 'status': '404 Not Found'}), 404
+            elif result.modified_count == 0:
+                return jsonify({'message': 'There was no trailer to be deleted', 'status': '200 OK'}), 200
+            return redirect(url_for('movies'))
+        else:
+            return jsonify({'error': 'Missing data or incorrect method', 'status': '400 Bad Request'}), 400

--- a/controllers/season_ctrl.py
+++ b/controllers/season_ctrl.py
@@ -257,3 +257,38 @@ class SeasonCtrl:
 
         else:
             return jsonify({'error': 'Falta de datos o método incorrecto', 'status': '400 Bad Request'}), 400
+
+    @staticmethod
+    def putTrailerIntoSeason(seasons: Collection, trailers: Collection, idSeason: int):
+        idTrailer = request.args.get('idTrailer')
+        if idTrailer:
+            idTrailer = int(idTrailer)
+            if trailers.find({'idTrailer': idTrailer}):
+                filter = {'idSeason': int(idSeason)}
+                change = {'$set': {'trailer': idTrailer}}
+                result = seasons.update_one(filter, change)
+                print(result)
+                if result.matched_count == 0:
+                    return jsonify({'error': 'Season not found or not updated', 'status': '404 Not Found'}), 404
+                elif result.modified_count == 0:
+                    return jsonify({'message': 'New trailer matches with current trailer', 'status': '200 OK'}), 200
+                return redirect(url_for('seasons'))
+            else:
+                return jsonify({'error': 'No trailer was found', 'status': '404 Not Found'}), 400
+        else:
+            return jsonify({'error': 'Missing data or incorrect method', 'status': '400 Bad Request'}), 400
+
+    @staticmethod
+    def deleteTrailerFromSeason(db: Collection, idSeason:int):
+        if idSeason:
+            filter = {'idSeason': int(idSeason)}
+            change = {'$set': {'trailer': None}}
+            result = db.update_one(filter, change)
+            print(result)
+            if result.matched_count == 0:
+                return jsonify({'error': 'Season not found or not updated', 'status': '404 Not Found'}), 404
+            elif result.modified_count == 0:
+                return jsonify({'message': 'There was no trailer to be deleted', 'status': '200 OK'}), 200
+            return redirect(url_for('seasons'))
+        else:
+            return jsonify({'error': 'Missing data or incorrect method', 'status': '400 Bad Request'}), 400

--- a/controllers/series_ctrl.py
+++ b/controllers/series_ctrl.py
@@ -348,3 +348,38 @@ class SeriesCtrl:
             return redirect(url_for('series'))
 
         return jsonify({'error': 'Missing data or incorrect method', 'status': '400 Bad Request'}), 400
+
+    @staticmethod
+    def putTrailerIntoSeries(series: Collection, trailers: Collection, idSeries: int):
+        idTrailer = request.args.get('idTrailer')
+        if idTrailer:
+            idTrailer = int(idTrailer)
+            if trailers.find({'idTrailer': idTrailer}):
+                filter = {'idSeries': int(idSeries)}
+                change = {'$set': {'trailer': idTrailer}}
+                result = series.update_one(filter, change)
+                print(result)
+                if result.matched_count == 0:
+                    return jsonify({'error': 'Series not found or not updated', 'status': '404 Not Found'}), 404
+                elif result.modified_count == 0:
+                    return jsonify({'message': 'New trailer matches with current trailer', 'status': '200 OK'}), 200
+                return redirect(url_for('series'))
+            else:
+                return jsonify({'error': 'No trailer was found', 'status': '404 Not Found'}), 400
+        else:
+            return jsonify({'error': 'Missing data or incorrect method', 'status': '400 Bad Request'}), 400
+
+    @staticmethod
+    def deleteTrailerFromSeries(db: Collection, idSeries:int):
+        if idSeries:
+            filter = {'idSeries': int(idSeries)}
+            change = {'$set': {'trailer': None}}
+            result = db.update_one(filter, change)
+            print(result)
+            if result.matched_count == 0:
+                return jsonify({'error': 'Series not found or not updated', 'status': '404 Not Found'}), 404
+            elif result.modified_count == 0:
+                return jsonify({'message': 'There was no trailer to be deleted', 'status': '200 OK'}), 200
+            return redirect(url_for('seasons'))
+        else:
+            return jsonify({'error': 'Missing data or incorrect method', 'status': '400 Bad Request'}), 400


### PR DESCRIPTION
- Asignar tráiler a película
- Asignar tráiler a serie
- Asignar tráiler a temporada Se pueden asignar tráileres y se pueden eliminar la asociación. No se elimina el tráiler de la base de datos si se le quita del contenido.

Ejemplos de petición CURL (idMovie e idTrailer deben existir):

```shell
curl -X PUT http://127.0.0.1:8082/movies/3/trailer?idTrailer=2
curl -X DELETE http://127.0.0.1:8082/movies/3/trailer
```